### PR TITLE
Fix WebSocket mixed content issue

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -9,7 +9,8 @@ const stopBtn = document.getElementById('stopBtn');
 const hal = document.getElementById('hal-container');
 
 startBtn.addEventListener('click', async () => {
-    ws = new WebSocket(`ws://${location.host}/ws`);
+    const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
+    ws = new WebSocket(`${wsProtocol}://${location.host}/ws`);
     ws.onmessage = handleMessage;
     await startAudio();
     startBtn.disabled = true;


### PR DESCRIPTION
## Summary
- use secure WebSocket protocol when page is served over HTTPS

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686ff77a57788323947acb7eb0a81573