### PR TITLE
Fix overlapping audio playback

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -127,6 +127,9 @@ function playAudio(pcm) {
     const src = audioContext.createBufferSource();
     src.buffer = buffer;
     src.connect(audioContext.destination);
+    if (nextPlaybackTime < audioContext.currentTime) {
+        nextPlaybackTime = audioContext.currentTime;
+    }
     src.start(nextPlaybackTime);
     const rms = Math.sqrt(pcm.reduce((s, v) => s + v * v, 0) / pcm.length);
     const scale = 1 + rms * 2;


### PR DESCRIPTION
## Summary
- ensure `nextPlaybackTime` never falls behind current time

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6870151ee98c8323a3a3061dfd8dd727