### PR TITLE
Integrate HAL 9000 styling and power switch

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -7,23 +7,20 @@ let pulseTimeout;
 let nextPlaybackTime = 0;
 let activeSources = [];
 
-const startBtn = document.getElementById('startBtn');
-const stopBtn = document.getElementById('stopBtn');
+const powerSwitch = document.getElementById('powerSwitch');
 const hal = document.getElementById('hal-container');
 
-startBtn.addEventListener('click', async () => {
-    ws = new WebSocket(`ws://${location.host}/ws`);
-    ws.onmessage = handleMessage;
-    await startAudio();
-    startBtn.disabled = true;
-    stopBtn.disabled = false;
-});
-
-stopBtn.addEventListener('click', () => {
-    stopAudio();
-    ws.close();
-    startBtn.disabled = false;
-    stopBtn.disabled = true;
+powerSwitch.addEventListener('change', async () => {
+    if (powerSwitch.checked) {
+        ws = new WebSocket(`ws://${location.host}/ws`);
+        ws.onmessage = handleMessage;
+        await startAudio();
+    } else {
+        stopAudio();
+        if (ws) {
+            ws.close();
+        }
+    }
 });
 
 function handleMessage(event) {

--- a/static/index.html
+++ b/static/index.html
@@ -8,11 +8,20 @@
     <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-    <div id="hal-container">
-        <div id="hal-eye"></div>
+    <div class="panel">
+        <div class="nameplate">Hal 9000</div>
+        <div class="base">
+            <div class="lens" id="hal-container">
+                <div class="reflections"></div>
+            </div>
+            <div class="animation"></div>
+        </div>
+        <div class="speaker"></div>
+        <label class="switch">
+            <input type="checkbox" id="powerSwitch">
+            <span class="slider"></span>
+        </label>
     </div>
-    <button id="startBtn">Start</button>
-    <button id="stopBtn" disabled>Stop</button>
     <script src="/app.js"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,56 +1,291 @@
 body {
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
     min-height: 100vh;
-    background: #000;
+    background: #0d0f23;
     color: #fff;
     font-family: Arial, sans-serif;
-}
-
-#hal-container {
-    width: 400px;
-    height: 400px;
-    border-radius: 50%;
-    background: radial-gradient(circle at center, #ffae00 0%, #ff2200 40%, #7f0000 80%, #000 100%);
-    box-shadow: 0 0 40px 10px rgba(255,0,0,0.9);
     position: relative;
-    margin-bottom: 20px;
 }
 
-#hal-eye::after {
+body::before {
+    background: #0d0f23;
+    content: '';
+    mix-blend-mode: color-dodge;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 10000;
+}
+
+.panel {
+    background: linear-gradient(90deg,#1f2344,#94a4ba,#404974,#94a4ba,#c2cad4);
+    border-radius: 0;
+    margin: 0 auto;
+    padding: 7px;
+    width: 322px;
+    height: 985px;
+    position: relative;
+}
+
+.panel::before {
+    background: linear-gradient(#53658c,#0f1029,#52638a);
     content: '';
     position: absolute;
-    left: 50%;
-    top: 50%;
-    width: 120px;
-    height: 120px;
-    margin-left: -60px;
-    margin-top: -60px;
-    border-radius: 50%;
-    background: radial-gradient(circle at center, #fff 0%, #ff3300 40%, #7f0000 80%, #000 100%);
-    transform: scale(var(--pulse-scale, 1));
-    transition: transform 0.1s linear;
-    opacity: 0;
+    top: 0;
+    left: 0;
+    width: 308px;
+    height: 971px;
 }
 
-
-.speaking #hal-eye::after {
-    opacity: 1;
+.panel::after {
+    background: radial-gradient(ellipse,#13142d,#08081a);
+    box-shadow: inset 0 0 80px #0b0a1f;
+    content: '';
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    width: 298px;
+    height: 961px;
 }
 
-
-button {
-    margin: 5px;
-    padding: 10px 20px;
-    background: #222;
+.nameplate {
+    background: linear-gradient(90deg,#0094ce 50%,transparent 50%);
+    border: 1px solid #0094ce;
+    border-radius: 0;
     color: #fff;
-    border: 1px solid #555;
-    cursor: pointer;
+    font-size: 41px;
+    font-family: 'Fjalla One',sans-serif;
+    line-height: 56px;
+    text-align: center;
+    text-indent: 0.85em;
+    -webkit-text-fill-color: transparent;
+    -webkit-text-stroke-width: 1px;
+    -webkit-text-stroke-color: #fff;
+    position: absolute;
+    top: 25px;
+    left: 25px;
+    width: 255px;
+    height: 56px;
+    z-index: 100;
 }
 
-button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+.speaker {
+    background-color: #0f122a;
+    background-image: linear-gradient(rgba(233,236,240,0.4),rgba(18,20,44,0.4)),
+        radial-gradient(#0d0f23 40%,transparent 40%),
+        radial-gradient(#13142d 40%,transparent 41%);
+    background-size: 100% 100%,12px 12px,12px 12px;
+    background-position: 0 0,0 0,0 2px;
+    background-blend-mode: overlay,normal,normal;
+    border-radius: 0;
+    box-shadow: inset 0 0 13px #0b0a1f;
+    width: 298px;
+    height: 205px;
+    position: absolute;
+    bottom: 11px;
+    left: 13px;
+}
+
+.speaker::before,
+.speaker::after {
+    content: '';
+    position: absolute;
+    width: 308px;
+    height: 5px;
+    left: -6px;
+}
+
+.speaker::before {
+    background: linear-gradient(90deg,#353f60,#c2cad4,#343e5f);
+}
+
+.speaker::after {
+    border: 5px solid transparent;
+    border-top-color: #1c2242;
+    top: 5px;
+}
+
+.base {
+    background-image: linear-gradient(45deg,#fefefe 10%,#5d6d94,#050718,#5d6d94,#fefefe 90%);
+    height: 260px;
+    width: 260px;
+    padding: 10px;
+    position: absolute;
+    bottom: 295px;
+    left: 33px;
+}
+
+.base::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-image: linear-gradient(#d9dee5,#151531),
+        linear-gradient(90deg,#434c77,#0b0a1f,#434c77);
+    background-blend-mode: hard-light,normal;
+    box-shadow: inset 0 0 14px 9px rgba(5,7,24,0.4);
+    width: 240px;
+    height: 240px;
+}
+
+.base::after {
+    content: '';
+    position: absolute;
+    background-image: radial-gradient(#b10000 10%,rgba(177,0,0,0) 71%);
+    mix-blend-mode: lighten;
+    top: -8px;
+    left: -10px;
+    width: 280px;
+    height: 280px;
+}
+
+/* lens doubles as hal-container for JS */
+.lens {
+    --pulse-scale: 1;
+    background-image: radial-gradient(#b10000 12%,#120619 67%,#200517);
+    border: 8px solid #050718;
+    box-shadow: inset 0 0 0 10px #380014;
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    width: 213px;
+    height: 213px;
+    transition: transform 0.1s linear;
+    transform: scale(var(--pulse-scale));
+}
+
+.lens::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: radial-gradient(#f00 20%,#470010 50%,#1a193e 80%);
+    mix-blend-mode: soft-light;
+    opacity: 0.8;
+    z-index: 100;
+    border-radius: inherit;
+}
+
+.lens::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: radial-gradient(#fff 2px,#fff300 8px,rgba(255,0,0,0.9) 14px,rgba(255,0,0,0.08) 35px,transparent 35px);
+    z-index: 100;
+    border-radius: inherit;
+}
+
+.speaking {
+    filter: brightness(1.4);
+}
+
+.reflections,
+.reflections::before,
+.reflections::after {
+    background-image: radial-gradient(transparent 19%,#ec32aa 23%,#d4f6fc 28%,#ec32aa 33%,transparent 36%,transparent 38%,#e558d0 40%,#d0fcfe 45%,#ce73df 50%,transparent 52%,transparent 56%,#b883e7 60%,#b7ffff 65%,#3564c7 72%,transparent);
+    background-size: 182px 182px;
+    background-position: top center;
+    border-radius: 15px 15px 5px 5px/5px 5px 15px 15px;
+    filter: blur(4px);
+    position: absolute;
+    top: 26px;
+    width: 58px;
+    height: 75px;
+    z-index: 10;
+}
+
+.reflections {
+    left: 69px;
+    transform: perspective(30px) rotate3d(1,0,0,-15deg);
+    transform-origin: top;
+}
+
+.reflections::before,
+.reflections::after {
+    content: '';
+    position: absolute;
+    height: 45px;
+    top: 28px;
+}
+
+.reflections::before {
+    left: -65px;
+    transform: rotate(-43deg);
+}
+
+.reflections::after {
+    right: -65px;
+    transform: rotate(43deg);
+}
+
+.animation {
+    animation: flicker 3s infinite;
+    background: radial-gradient(#79b4ba,#47696d,#890000);
+    mix-blend-mode: color-dodge;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    border-radius: inherit;
+}
+
+@keyframes flicker {
+    0% { opacity: 0; }
+    15% { opacity: 1; }
+    75% { opacity: 0; }
+}
+
+.switch {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+}
+
+.switch input { display: none; }
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #555;
+    transition: .4s;
+    border-radius: 34px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+input:checked + .slider {
+    background-color: #2196F3;
+}
+
+input:checked + .slider:before {
+    transform: translateX(26px);
 }


### PR DESCRIPTION
## Summary
- modernize frontend with HAL 9000 themed markup
- implement on/off switch and remove start/stop buttons
- update JavaScript to use the switch for recording control
- replace styling with HAL panel look and pulsing lens effect

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68701f52b55c83238ea461ae7f98e67c