### PR TITLE
Enable flicker pulses when HAL speaks

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -10,6 +10,7 @@ let activeSources = [];
 const startBtn = document.getElementById('startBtn');
 const stopBtn = document.getElementById('stopBtn');
 const hal = document.querySelector('.animation');
+hal.classList.add('idle');
 
 startBtn.addEventListener('click', async () => {
     ws = new WebSocket(`ws://${location.host}/ws`);
@@ -98,6 +99,7 @@ function clearAudio() {
         nextPlaybackTime = 0;
     }
     hal.classList.remove('speaking');
+    hal.classList.add('idle');
 }
 
 function floatTo16BitPCM(input) {
@@ -151,13 +153,14 @@ function playAudio(pcm) {
     }
     src.start(nextPlaybackTime);
     activeSources.push(src);
+    hal.classList.remove('idle');
+    hal.classList.add('speaking');
     src.onended = () => {
         activeSources = activeSources.filter(s => s !== src);
+        if (activeSources.length === 0) {
+            hal.classList.remove('speaking');
+            hal.classList.add('idle');
+        }
     };
-    hal.classList.add('speaking');
-    clearTimeout(pulseTimeout);
-    pulseTimeout = setTimeout(() => {
-        hal.classList.remove('speaking');
-    }, 80);
     nextPlaybackTime += buffer.duration;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -17,6 +17,8 @@
             <div class="animation"></div>
         </div>
         <div class="speaker"></div>
+    </div>
+    <div class="ui-overlay">
         <button id="startBtn">Start</button>
         <button id="stopBtn" disabled>Stop</button>
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -14,6 +14,11 @@ body {
     left: 0;
     z-index: 10000; }
 
+.ui-overlay {
+  position: relative;
+  z-index: 10001; /* mayor que el body::before */
+}
+
 /* Basic setup */
 div {
   border-radius: 100%;
@@ -195,18 +200,42 @@ div {
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 1000; }
+  z-index: 1000;
+  pointer-events: none;
+}
 
+/* Estado de poca actividad (parpadeo lento, suave) */
+.animation.idle {
+  animation: flickerIdle 1.5s infinite;
+}
+
+/* Estado de mucha actividad (parpadeo rápido e intenso) */
 .animation.speaking {
-  animation: flicker 0.3s infinite; }
+  animation: flickerSpeaking 0.3s infinite;
+}
 
-@keyframes flicker {
+/* Animación suave (poca actividad) */
+@keyframes flickerIdle {
+  0%, 100% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+/* Animación intensa (mucha actividad) */
+@keyframes flickerSpeaking {
   0% {
-    opacity: 0; }
+    opacity: 0;
+  }
   15% {
-    opacity: 1; }
+    opacity: 1;
+  }
   75% {
-    opacity: 0; } }
+    opacity: 0;
+  }
+}
 
 button {
     margin: 5px;


### PR DESCRIPTION
## Summary
- update JS to control the new `.animation` element
- use CSS class to start flicker effect when audio plays

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6870471199b883238c241f7df66b5dda