### PR TITLE
Support async functions

### DIFF
--- a/main.py
+++ b/main.py
@@ -151,7 +151,10 @@ async def handle_media_stream(websocket: WebSocket):
                                     args = json.loads(call["arguments"] or "{}")
                                 except json.JSONDecodeError:
                                     args = {}
-                                result = func(**args)
+                                if asyncio.iscoroutinefunction(func):
+                                    result = await func(**args)
+                                else:
+                                    result = func(**args)
                             else:
                                 result = {"error": f"Unknown function {call['name']}"}
                             output_event = {


### PR DESCRIPTION
## Summary
- handle async registered functions when function calls are processed
- install dependencies and run a basic server smoke test

## Testing
- `python -m py_compile main.py`
- `OPENAI_API_KEY=dummy python main.py` *(fails: proxy rejected connection)*


------
https://chatgpt.com/codex/tasks/task_e_687e5f2e27d08323957e68e07e86ce10