### PR TITLE
Add async RAG search with Qdrant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ OPENAI_MODEL=gpt-4o-mini-realtime-preview-2024-12-17
 PORT=5050
 TIMEZONE=Atlantic/Canary
 TURN_DETECTION_MODE=semantic_vad
+QDRANT_URL=http://localhost:6333
+RAG_DOCS_DIR=./docs
+RAG_COLLECTION=rag_docs
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ docker compose up --build
 - Basic interruption handling when you talk over HAL
 - Demonstrates Realtime API function calling with `get_current_time`
   and `hal9000_system_analysis` tools
+- Includes a retrieval-augmented generation tool using Qdrant
+  for hybrid (dense + sparse) document search with paragraph chunking
+  powered by OpenAI embeddings. See the
+  [hybrid search tutorial](https://qdrant.tech/documentation/advanced-tutorials/reranking-hybrid-search/)
+  and [async API guide](https://qdrant.tech/documentation/database-tutorials/async-api/)
+  for details.
 - The time zone used by `get_current_time` is configurable with the
   `TIMEZONE` variable (defaults to `Atlantic/Canary`). If the specified zone is
   unavailable, the server falls back to `UTC`.
@@ -55,5 +61,22 @@ docker compose up --build
   HAL detects turns (defaults to `semantic_vad`)
 - Audio is exchanged as 16-bit little-endian PCM at 24kHz over the WebSocket
   connection, and HAL responds in the same 24kHz PCM format
+
+## RAG Setup
+
+The assistant can search local documents using Qdrant. Set the following
+environment variables or update `.env`:
+
+- `QDRANT_URL` – URL for the Qdrant instance (default `http://localhost:6333`)
+- `RAG_DOCS_DIR` – directory containing text files to index (default `./docs`)
+- `RAG_COLLECTION` – collection name in Qdrant (default `rag_docs`)
+
+Set `OPENAI_EMBEDDING_MODEL` to choose the model used for embeddings
+(default `text-embedding-3-small`).
+
+Place your documents in `RAG_DOCS_DIR` before starting the server. Paragraphs
+are indexed using OpenAI embeddings combined with TF‑IDF sparse vectors. The top
+results are optionally reranked using OpenAI's API to return the ten most
+relevant chunks.
 
 Have fun—and remember, HAL is always listening.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,16 @@
 services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+
   app:
     build: .
     env_file: .env
+    depends_on:
+      - qdrant
     ports:
       - "${PORT:-5050}:5050"
     environment:
@@ -9,3 +18,11 @@ services:
       - OPENAI_MODEL=${OPENAI_MODEL}
       - PORT=${PORT}
       - TURN_DETECTION_MODE=${TURN_DETECTION_MODE}
+      - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
+      - RAG_DOCS_DIR=${RAG_DOCS_DIR:-/app/docs}
+      - RAG_COLLECTION=${RAG_COLLECTION:-rag_docs}
+    volumes:
+      - ${RAG_DOCS_DIR:-./docs}:/app/docs
+
+volumes:
+  qdrant_data:

--- a/docs/example.txt
+++ b/docs/example.txt
@@ -1,0 +1,2 @@
+This is a sample document.
+You can replace this with your own files for indexing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn==0.35.0
 websockets==15.0.1
 python-dotenv==1.1.1
 tzdata
+qdrant-client==1.8.1
+openai>=1.0


### PR DESCRIPTION
## Summary
- use `AsyncQdrantClient` and `AsyncOpenAI` for RAG
- add links to Qdrant hybrid search and async API docs in README
- hybrid search and rerank now run asynchronously

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_688107c6e0d8832385a1134ea7269b13