### PR TITLE
Add RAG tool with Qdrant in-memory store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ OPENAI_MODEL=gpt-4o-mini-realtime-preview-2024-12-17
 PORT=5050
 TIMEZONE=Atlantic/Canary
 TURN_DETECTION_MODE=semantic_vad
+RAG_DOCS_DIR=./rag_docs
+RAG_COLLECTION=qdrant_collection_name
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, WebSocket
 from fastapi.responses import JSONResponse
 from fastapi.websockets import WebSocketDisconnect
 from dotenv import load_dotenv
+from rag_tool import init_rag, query_rag
 from datetime import datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -59,6 +60,9 @@ SHOW_TIMING_MATH = False
 from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
+@app.on_event("startup")
+async def _rag_startup():
+    await init_rag()
 
 # Function calling setup
 def get_current_time() -> dict:
@@ -86,6 +90,7 @@ async def hal9000_system_analysis(mode: str = "simple") -> dict:
 FUNCTIONS = {
     "get_current_time": get_current_time,
     "hal9000_system_analysis": hal9000_system_analysis,
+    "query_rag": query_rag,
 }
 
 # Track function call data by item_id
@@ -279,6 +284,18 @@ async def initialize_session(openai_ws):
                                 "default": "simple",
                             }
                         },
+                    },
+                },
+                {
+                    "type": "function",
+                    "name": "query_rag",
+                    "description": "Search the RAG documents",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"}
+                        },
+                        "required": ["query"]
                     },
                 },
             ],

--- a/main.py
+++ b/main.py
@@ -49,12 +49,13 @@ LOG_EVENT_TYPES = [
     "error",
     "response.content.done",
     "rate_limits.updated",
+    "conversation.item.created",
     "response.done",
     "input_audio_buffer.committed",
     "input_audio_buffer.speech_stopped",
     "input_audio_buffer.speech_started",
     "session.created",
-    "conversation.item.created",
+    "session.update",
 ]
 SHOW_TIMING_MATH = False
 
@@ -120,6 +121,7 @@ async def handle_media_stream(websocket: WebSocket):
     print("Client connected")
     await websocket.accept()
 
+    # see https://platform.openai.com/docs/guides/realtime-conversations#handling-audio-with-websockets
     async with websockets.connect(
         f"wss://api.openai.com/v1/realtime?model={OPENAI_MODEL}",
         additional_headers={
@@ -277,13 +279,13 @@ async def initialize_session(openai_ws):
                 {
                     "type": "function",
                     "name": "get_current_time",
-                    "description": "Return the current time",
+                    "description": "Return the current time.",
                     "parameters": {"type": "object", "properties": {}},
                 },
                 {
                     "type": "function",
                     "name": "hal9000_system_analysis",
-                    "description": "Simulate a HAL 9000 system analysis",
+                    "description": "Simulate a HAL 9000 system analysis.",
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -298,7 +300,7 @@ async def initialize_session(openai_ws):
                 {
                     "type": "function",
                     "name": "query_rag",
-                    "description": "Retrieve the most relevant historical and cultural information about 'La Casa de los Balcones' located in La Orotava, Tenerife. Focus on architectural features, history, notable figures associated with the house, and any relevant cultural significance.",
+                    "description": "Retrieve the most relevant historical and cultural information about 'La Casa de los Balcones' located in La Orotava, Tenerife.",
                     "parameters": {
                         "type": "object",
                         "properties": {

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from websockets.protocol import State
 from fastapi import FastAPI, WebSocket
 from fastapi.responses import JSONResponse
 from fastapi.websockets import WebSocketDisconnect
+from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 from rag_tool import init_rag, query_rag
 from datetime import datetime
@@ -59,10 +60,18 @@ SHOW_TIMING_MATH = False
 
 from fastapi.staticfiles import StaticFiles
 
-app = FastAPI()
-@app.on_event("startup")
-async def _rag_startup():
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup logic
     await init_rag()
+    yield
+    # Shutdown logic (if needed)
+    # e.g. await qdrant_client.close() or db_client.disconnect()
+    # currently empty
+
+app = FastAPI(lifespan=lifespan)
+
 
 # Function calling setup
 def get_current_time() -> dict:
@@ -289,7 +298,7 @@ async def initialize_session(openai_ws):
                 {
                     "type": "function",
                     "name": "query_rag",
-                    "description": "Search the RAG documents",
+                    "description": "Retrieve the most relevant historical and cultural information about 'La Casa de los Balcones' located in La Orotava, Tenerife. Focus on architectural features, history, notable figures associated with the house, and any relevant cultural significance.",
                     "parameters": {
                         "type": "object",
                         "properties": {

--- a/rag_docs/docs.txt
+++ b/rag_docs/docs.txt
@@ -1,15 +1,49 @@
-Using FastEmbed with Qdrant for Vector Search
-Install Qdrant Client and FastEmbed
-pip install "qdrant-client[fastembed]>=1.14.2"
+¿Qué tipo de maderas se usaron para construir los balcones y elementos interiores?
+Se utilizó principalmente madera de tea (corazón de pino canario) por su resistencia y durabilidad, junto con otras maderas nobles locales para detalles decorativos y mobiliario.
 
-Initialize the client
-Qdrant Client has a simple in-memory mode that lets you try semantic search locally.
+¿Cuántos balcones originales se conservan desde su construcción?
+Se conservan los balcones principales de la fachada y varios interiores, restaurados siguiendo técnicas tradicionales para mantener su aspecto y estructura originales.
 
-from qdrant_client import QdrantClient, models
+¿Qué familias vivieron aquí y qué aportaron a la historia local?
+Fue residencia de la familia Machado y Méndez, una de las más influyentes de La Orotava, vinculada al comercio, la agricultura y la promoción de las artes y la cultura local.
 
-client = QdrantClient(":memory:")  # Qdrant is running from RAM.
+¿Se pueden ver habitaciones originales tal como se usaban?
+Sí, varias estancias conservan mobiliario, utensilios y decoración de época, recreando la forma de vida de la burguesía canaria entre los siglos XVII y XIX.
 
-Add data
-Now you can add two sample documents, their associated metadata, and a point id for each.
+¿Qué simbolizan los detalles tallados en los balcones y columnas?
+Los motivos tallados reflejan elementos de la naturaleza, símbolos religiosos y heráldica familiar, mostrando la relevancia social de los propietarios y el talento de los artesanos locales.
 
-# .. truncated for brevity ..
+¿Hay piezas de artesanía originales de la época?
+Sí, se exponen muebles, cofres, herramientas de trabajo y utensilios domésticos auténticos, muchos de ellos fabricados en talleres canarios de la época.
+
+¿Qué textiles o bordados tradicionales se exponen?
+La Casa muestra una valiosa colección de bordados, encajes y trajes típicos, incluyendo mantillas, calados y ropas tradicionales usados en festividades y vida cotidiana.
+
+¿Puedo ver demostraciones en vivo de artesanía canaria?
+Sí, en ocasiones se organizan demostraciones de calado canario, bordado y otras técnicas tradicionales, realizadas por artesanas locales que mantienen viva la tradición.
+
+¿Cuál es la pieza más valiosa o curiosa de la colección?
+Una de las más valoradas es el balcón principal de tea labrado a mano y, entre las piezas interiores, destaca un arcón tallado del siglo XVIII y piezas textiles de gran finura.
+
+¿Qué secretos arquitectónicos tiene la casa? (pasadizos, sótanos, aljibes)
+La casa conserva un antiguo aljibe para recoger agua de lluvia y un patio central que articula la vivienda.
+
+¿Por qué se considera un icono de la arquitectura tradicional canaria?
+Por su fachada con balcones de madera, patios interiores, empleo de piedra y tea, y la fusión de estilos mudéjar e influencias coloniales que representan la identidad canaria.
+
+¿Hay patio interior visitable y qué plantas se cultivan en él?
+Sí, el patio interior es uno de los espacios más admirados, con vegetación autóctona como helechos, geranios y flores tradicionales, creando un ambiente fresco y luminoso.
+
+¿Qué eventos históricos ocurrieron dentro de la casa?
+La casa fue testigo de reuniones sociales y políticas relevantes, celebraciones familiares y actividades relacionadas con la economía agrícola y la defensa de la cultura local.
+
+¿Se puede acceder a la parte superior de los balcones?
+Sí, algunos balcones se pueden recorrer desde el interior de la casa para observar la estructura y disfrutar de vistas al patio y a la calle principal de La Orotava.
+
+¿Hay alguna historia o leyenda vinculada a la Casa de los Balcones?
+Se dice que en algunas noches se escuchan susurros de antiguos habitantes, y que los balcones servían para observar procesiones y festejos sin ser vistos, reforzando el misticismo de la casa.
+
+¿Cuánto se tarda en hacer un mantel?
+Trabajando unas cinco chicas se tardará alrededor de un mes.
+El proceso del calado es el siguiente: marcar, sacar un hilo doble espigueta para dar fijeza al trabajo y hacer las patas y los cuadros. Lo más difícil es el marcado, que consiste en cortar los hilos. Eso sí, no uno más ni uno menos.
+Una hebra que salga de su sitio puede destrozar el trabajo. Todas mis alumnas saben calar, pero no todas saben marcar.

--- a/rag_docs/docs.txt
+++ b/rag_docs/docs.txt
@@ -1,0 +1,15 @@
+Using FastEmbed with Qdrant for Vector Search
+Install Qdrant Client and FastEmbed
+pip install "qdrant-client[fastembed]>=1.14.2"
+
+Initialize the client
+Qdrant Client has a simple in-memory mode that lets you try semantic search locally.
+
+from qdrant_client import QdrantClient, models
+
+client = QdrantClient(":memory:")  # Qdrant is running from RAM.
+
+Add data
+Now you can add two sample documents, their associated metadata, and a point id for each.
+
+# .. truncated for brevity ..

--- a/rag_tool.py
+++ b/rag_tool.py
@@ -1,9 +1,12 @@
 import os
 import glob
 from typing import List
+from dotenv import load_dotenv
 
 from openai import AsyncOpenAI
 from qdrant_client import QdrantClient, models
+
+load_dotenv()
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-3-small")
@@ -37,7 +40,7 @@ async def init_rag() -> None:
         return
     embeddings = await _embed(paragraphs)
     vector_size = len(embeddings[0])
-    client.recreate_collection(
+    client.create_collection(
         collection_name=collection_name,
         vectors_config=models.VectorParams(size=vector_size, distance=models.Distance.COSINE),
     )

--- a/rag_tool.py
+++ b/rag_tool.py
@@ -1,0 +1,54 @@
+import os
+import glob
+from typing import List
+
+from openai import AsyncOpenAI
+from qdrant_client import QdrantClient, models
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-3-small")
+RAG_DOCS_DIR = os.getenv("RAG_DOCS_DIR", "rag_docs")
+
+openai_client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+
+client = QdrantClient(":memory:")
+
+collection_name = "rag_docs"
+
+async def _embed(texts: List[str]) -> List[List[float]]:
+    resp = await openai_client.embeddings.create(model=EMBED_MODEL, input=texts)
+    return [d.embedding for d in resp.data]
+
+def _load_paragraphs() -> List[str]:
+    paragraphs: List[str] = []
+    for path in glob.glob(os.path.join(RAG_DOCS_DIR, "*")):
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+                for p in text.split("\n\n"):
+                    p = p.strip()
+                    if p:
+                        paragraphs.append(p)
+    return paragraphs
+
+async def init_rag() -> None:
+    paragraphs = _load_paragraphs()
+    if not paragraphs:
+        return
+    embeddings = await _embed(paragraphs)
+    vector_size = len(embeddings[0])
+    client.recreate_collection(
+        collection_name=collection_name,
+        vectors_config=models.VectorParams(size=vector_size, distance=models.Distance.COSINE),
+    )
+    points = [
+        models.PointStruct(id=i, vector=emb, payload={"document": doc})
+        for i, (emb, doc) in enumerate(zip(embeddings, paragraphs))
+    ]
+    client.upsert(collection_name=collection_name, points=points)
+
+
+async def query_rag(query: str, top_k: int = 3) -> dict:
+    query_vector = (await _embed([query]))[0]
+    hits = client.search(collection_name=collection_name, query_vector=query_vector, limit=top_k, with_payload=True)
+    return {"results": [hit.payload.get("document", "") for hit in hits]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn==0.35.0
 websockets==15.0.1
 python-dotenv==1.1.1
 tzdata
+qdrant-client==1.15.0
+openai==1.97.1


### PR DESCRIPTION
## Summary
- add OpenAI + Qdrant RAG helper
- expose `query_rag` tool to realtime API
- install qdrant-client and openai dependencies
- include sample docs

## Testing
- `python -m py_compile main.py rag_tool.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68826562cb8083239c19766f3fce1806