### PR TITLE
Add score-based reranker and filter RAG results

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,10 +47,12 @@ SYSTEM_MESSAGE = """
 """
 LOG_EVENT_TYPES = [
     "error",
-    "response.content.done",
+    "response.create",
+    "response.done",
+    "response.function_call_arguments.done",
+    "response.output_item.done",
     "rate_limits.updated",
     "conversation.item.created",
-    "response.done",
     "input_audio_buffer.committed",
     "input_audio_buffer.speech_stopped",
     "input_audio_buffer.speech_started",
@@ -300,7 +302,7 @@ async def initialize_session(openai_ws):
                 {
                     "type": "function",
                     "name": "query_rag",
-                    "description": "Retrieve the most relevant historical and cultural information about 'La Casa de los Balcones' located in La Orotava, Tenerife.",
+                    "description": "Use always this tool to retrieve all historical and cultural information about 'La Casa de los Balcones' located in La Orotava, Tenerife.",
                     "parameters": {
                         "type": "object",
                         "properties": {

--- a/openai_reranker.py
+++ b/openai_reranker.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Tuple
+
+from openai import AsyncOpenAI
+
+class OpenAILlmReranker:
+    """Rerank documents for a query using an OpenAI chat model."""
+
+    def __init__(self, api_key: str, model: str = "gpt-4o") -> None:
+        self.client = AsyncOpenAI(api_key=api_key)
+        self.model = model
+
+    async def rerank(
+        self, query: str, docs: List[str], min_score: float = 0.0
+    ) -> List[Tuple[str, float]]:
+        """Return (document, score) pairs ordered by score and filtered."""
+        if not docs:
+            return []
+
+        doc_list = "\n".join(f"{i + 1}. {doc}" for i, doc in enumerate(docs))
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful assistant that scores each document from 0 to 10 "
+                    "by its relevance to the user query. Respond with a JSON array of "
+                    "objects containing 'index' and 'score', sorted by score."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Query: {query}\n\nDocuments:\n{doc_list}\n\nReturn the scores.",
+            },
+        ]
+        resp = await self.client.chat.completions.create(
+            model=self.model, messages=messages, temperature=0
+        )
+        content = resp.choices[0].message.content
+        try:
+            items = json.loads(content)
+        except json.JSONDecodeError:
+            pattern = r"(\d+)\D+(\d+(?:\.\d+)?)"
+            items = [
+                {"index": int(i), "score": float(s)} for i, s in re.findall(pattern, content)
+            ]
+
+        scored_docs = [
+            (docs[item["index"] - 1], float(item["score"]))
+            for item in items
+            if 1 <= item["index"] <= len(docs)
+        ]
+        scored_docs.sort(key=lambda x: x[1], reverse=True)
+        return [(doc, score) for doc, score in scored_docs if score >= min_score]

--- a/openai_reranker.py
+++ b/openai_reranker.py
@@ -1,56 +1,82 @@
-from __future__ import annotations
-
-import json
 import re
 from typing import List, Tuple
 
 from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
+
 
 class OpenAILlmReranker:
     """Rerank documents for a query using an OpenAI chat model."""
 
-    def __init__(self, api_key: str, model: str = "gpt-4o") -> None:
+    def __init__(self, api_key: str, model: str = "gpt-4o-mini") -> None:
         self.client = AsyncOpenAI(api_key=api_key)
         self.model = model
 
     async def rerank(
-        self, query: str, docs: List[str], min_score: float = 0.0
-    ) -> List[Tuple[str, float]]:
+        self, query: str, docs: List[str], min_score: int = 5
+    ) -> List[Tuple[str, int]]:
         """Return (document, score) pairs ordered by score and filtered."""
+
         if not docs:
             return []
 
-        doc_list = "\n".join(f"{i + 1}. {doc}" for i, doc in enumerate(docs))
-        messages = [
-            {
-                "role": "system",
-                "content": (
-                    "You are a helpful assistant that scores each document from 0 to 10 "
-                    "by its relevance to the user query. Respond with a JSON array of "
-                    "objects containing 'index' and 'score', sorted by score."
-                ),
-            },
-            {
-                "role": "user",
-                "content": f"Query: {query}\n\nDocuments:\n{doc_list}\n\nReturn the scores.",
-            },
-        ]
-        resp = await self.client.chat.completions.create(
-            model=self.model, messages=messages, temperature=0
+        # Formatear contexto como en DEFAULT_CHOICE_SELECT_PROMPT_TMPL
+        context_str = "\n\n".join(
+            f"Document {i+1}:\n{doc}" for i, doc in enumerate(docs)
         )
-        content = resp.choices[0].message.content
-        try:
-            items = json.loads(content)
-        except json.JSONDecodeError:
-            pattern = r"(\d+)\D+(\d+(?:\.\d+)?)"
-            items = [
-                {"index": int(i), "score": float(s)} for i, s in re.findall(pattern, content)
-            ]
 
+        prompt = (
+            "A list of documents is shown below. Each document has a number next to it along "
+            "with a summary of the document. A question is also provided. \n"
+            "Respond with the numbers of the documents you should consult to answer the question, "
+            "in order of relevance, as well as the relevance score. The relevance score is a number "
+            "from 1-10 based on how relevant you think the document is to the question.\n"
+            f"Do not include any documents that are not relevant to the question or ranks less than {min_score}.\n"
+            "Example format: \n"
+            "Document 1:\n<summary of document 1>\n\n"
+            "Document 2:\n<summary of document 2>\n\n"
+            "...\n\n"
+            "Document 10:\n<summary of document 10>\n\n"
+            "Question: <question>\n"
+            "Answer:\n"
+            "Doc: 9, Relevance: 7\n"
+            "Doc: 3, Relevance: 4\n"
+            "Doc: 7, Relevance: 3\n\n"
+            "Let's try this now:\n\n"
+            f"{context_str}\n"
+            f"Question: {query}\n"
+            "Answer:\n"
+        )
+
+        messages: List[ChatCompletionSystemMessageParam | ChatCompletionUserMessageParam] = [
+            ChatCompletionSystemMessageParam(role="system",
+                                             content="You are a helpful assistant that ranks documents by relevance."),
+            ChatCompletionUserMessageParam(role="user", content=prompt),
+        ]
+
+        resp = await self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=0,
+        )
+
+        content = resp.choices[0].message.content or ""
+
+        # Parsear líneas tipo: "Doc: 2, Relevance: 9"
+        pattern = r"Doc:\s*(\d+),\s*Relevance:\s*(\d+)"
+        items = [
+            {"index": int(i), "score": int(score)}
+            for i, score in re.findall(pattern, content)
+        ]
+
+        # Filtrar resultados válidos
         scored_docs = [
-            (docs[item["index"] - 1], float(item["score"]))
+            (docs[item["index"] - 1], item["score"])
             for item in items
             if 1 <= item["index"] <= len(docs)
         ]
+
+        # Ordenar por score descendente
         scored_docs.sort(key=lambda x: x[1], reverse=True)
-        return [(doc, score) for doc, score in scored_docs if score >= min_score]
+
+        return scored_docs

--- a/rag_docs/docs.txt
+++ b/rag_docs/docs.txt
@@ -43,7 +43,6 @@ Sí, algunos balcones se pueden recorrer desde el interior de la casa para obser
 ¿Hay alguna historia o leyenda vinculada a la Casa de los Balcones?
 Se dice que en algunas noches se escuchan susurros de antiguos habitantes, y que los balcones servían para observar procesiones y festejos sin ser vistos, reforzando el misticismo de la casa.
 
-¿Cuánto se tarda en hacer un mantel?
-Trabajando unas cinco chicas se tardará alrededor de un mes.
-El proceso del calado es el siguiente: marcar, sacar un hilo doble espigueta para dar fijeza al trabajo y hacer las patas y los cuadros. Lo más difícil es el marcado, que consiste en cortar los hilos. Eso sí, no uno más ni uno menos.
-Una hebra que salga de su sitio puede destrozar el trabajo. Todas mis alumnas saben calar, pero no todas saben marcar.
+¿Quién está desarrollando esta aplicación?
+Proyectran, Diseño y Desarrollo Tecnológico
+Servicios de consultoría digital, diseño y desarrollo tecnológico para conseguir tus objetivos y darle forma a tus proyectos.

--- a/rag_tool.py
+++ b/rag_tool.py
@@ -6,6 +6,8 @@ from dotenv import load_dotenv
 from openai import AsyncOpenAI
 from qdrant_client import QdrantClient, models
 
+from openai_reranker import OpenAILlmReranker
+
 load_dotenv()
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -13,6 +15,8 @@ EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-3-small")
 RAG_DOCS_DIR = os.getenv("RAG_DOCS_DIR", "rag_docs")
 
 openai_client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+
+reranker = OpenAILlmReranker(api_key=OPENAI_API_KEY)
 
 client = QdrantClient(":memory:")
 
@@ -51,7 +55,18 @@ async def init_rag() -> None:
     client.upsert(collection_name=collection_name, points=points)
 
 
-async def query_rag(query: str, top_k: int = 3) -> dict:
+async def query_rag(query: str, top_k: int = 3, min_score: float = 0.0) -> dict:
     query_vector = (await _embed([query]))[0]
-    hits = client.search(collection_name=collection_name, query_vector=query_vector, limit=top_k, with_payload=True)
-    return {"results": [hit.payload.get("document", "") for hit in hits]}
+    hits = client.search(
+        collection_name=collection_name,
+        query_vector=query_vector,
+        limit=top_k,
+        with_payload=True,
+    )
+    docs = [hit.payload.get("document", "") for hit in hits]
+    reranked = await reranker.rerank(query, docs, min_score=min_score)
+    return {
+        "results": [
+            {"document": doc, "score": score} for doc, score in reranked
+        ]
+    }

--- a/rag_tool.py
+++ b/rag_tool.py
@@ -55,7 +55,7 @@ async def init_rag() -> None:
     client.upsert(collection_name=collection_name, points=points)
 
 
-async def query_rag(query: str, top_k: int = 3, min_score: float = 0.0) -> dict:
+async def query_rag(query: str, top_k: int = 5, min_score: int = 6.0) -> dict:
     query_vector = (await _embed([query]))[0]
     hits = client.search(
         collection_name=collection_name,
@@ -64,7 +64,9 @@ async def query_rag(query: str, top_k: int = 3, min_score: float = 0.0) -> dict:
         with_payload=True,
     )
     docs = [hit.payload.get("document", "") for hit in hits]
+    print("DOCS:", docs)
     reranked = await reranker.rerank(query, docs, min_score=min_score)
+    print("RERANK: ", reranked)
     return {
         "results": [
             {"document": doc, "score": score} for doc, score in reranked


### PR DESCRIPTION
## Summary
- implement `OpenAILlmReranker.rerank` to score docs 0-10 and filter by `min_score`
- create a global reranker and rerank results in `query_rag`

## Testing
- `python -m py_compile openai_reranker.py rag_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_68828af8e60c832381908d2a406cd24a